### PR TITLE
Feature: k8s service

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,8 @@ I use this to sftp into the cluster filesystem.
 
 ## Usage
 
+You can access the pod by connecting with ssh using the *root* user (`ssh -p <YOUR_ASSIGNED_NODE_PORT> root@<YOUR_SERVER_URL>`)
+
+or 
+
 You may now forward the ssh port to your local machine via `kubectl port-forward ssh 4444:22` and connect to it by using the *root* user (`ssh -p4444 root@localhost`).

--- a/k8s-ssh-pod.yaml
+++ b/k8s-ssh-pod.yaml
@@ -18,29 +18,11 @@ spec:
         - name: ssh
           image: corbinu/ssh-server
           volumeMounts:
-            - name: senteval-results-claim
-              mountPath: /pv/senteval-results-claim
-            - name: fasttext-model-wiki-en-claim
-              mountPath: /pv/fasttext-model-wiki-en-claim
-            - name: fasttext-model-cc-en-claim
-              mountPath: /pv/fasttext-model-cc-en-claim
-            - name: fasttext-vectors-cc-en-claim
-              mountPath: /pv/fasttext-vectors-cc-en-claim
-            - name: nir-treccds2015-vectors
-              mountPath: /pv/nir-treccds2015-vectors
-            - name: parvecrestencoder
-              mountPath: /pv/parvecrestencoder
-            - name: sector-model-claim
-              mountPath: /pv/sector-model-claim
-            - name: sector-pubmed-model-claim
-              mountPath: /pv/sector-pubmed-model-claim
-            - name: sector-pubmed-v3-model-claim
-              mountPath: /pv/sector-pubmed-v3-model-claim
             - name: ssh-key
               mountPath: /root/ssh-key
             - name: ceph-nfs
               mountPath: /pv/ceph-nfs
-          ports:
+          ports: 
             - containerPort: 22
           lifecycle:
             postStart:
@@ -51,33 +33,6 @@ spec:
           secret:
             secretName: my-ssh-public-key
             defaultMode: 256
-        - name: senteval-results-claim
-          persistentVolumeClaim:
-            claimName: senteval-results-claim
-        - name: fasttext-model-wiki-en-claim
-          persistentVolumeClaim:
-            claimName: fasttext-model-wiki-en-claim
-        - name: fasttext-model-cc-en-claim
-          persistentVolumeClaim:
-            claimName: fasttext-model-cc-en-claim
-        - name: fasttext-vectors-cc-en-claim
-          persistentVolumeClaim:
-            claimName: fasttext-vectors-cc-en-claim
-        - name: nir-treccds2015-vectors
-          persistentVolumeClaim:
-            claimName: nir-treccds2015-vectors
-        - name: parvecrestencoder
-          persistentVolumeClaim:
-            claimName: parvecrestencoder
-        - name: sector-model-claim
-          persistentVolumeClaim:
-            claimName: sector-model-claim
-        - name: sector-pubmed-model-claim
-          persistentVolumeClaim:
-            claimName: sector-pubmed-model-claim
-        - name: sector-pubmed-v3-model-claim
-          persistentVolumeClaim:
-            claimName: sector-pubmed-v3-model-claim
         - name: ceph-nfs
           flexVolume:
             driver: ceph.rook.io/rook

--- a/k8s-ssh-pod.yaml
+++ b/k8s-ssh-pod.yaml
@@ -85,3 +85,22 @@ spec:
             options:
               fsName: home
               clusterNamespace: rook-ceph
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ssh
+  labels:
+    app: ssh
+spec:
+  type: NodePort
+  ports:
+  - name: "22"
+    port: 22
+    # nodePort: ???  # dynamically set by k8 - you can set this value after assignment
+  selector:
+    app: ssh
+status:
+  loadBalancer: {}


### PR DESCRIPTION
Implemented a k8s service with a nodeport. With this the `kubectl` port-forward is now obsolet. You can easily access the pod directly with ssh.

Changes:

1. Added service section to the `k8s-ssh-pod.yaml`
2. Updated the `README` accordingly